### PR TITLE
Fixing typo on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
     <div class="featlist-text">
         <div class="featlist-title">Full Web Browser in your .Net App</div>
         <div class="featlist-desc">
-           CefSharp is the the easiest way to embed a full-featured standards-complaint web browser into your C# or VB.NET app. CefSharp has browser controls for WinForms and WPF apps, and a headless (offscreen) version for automation projects too. CefSharp is based on <a href="https://bitbucket.org/chromiumembedded/cef">Chromium Embedded Framework</a>, the open source version of <a href="https://www.google.com/chrome/">Google Chrome</a>. We have a simple 5 step process to get started. See the <a href="https://github.com/cefsharp/CefSharp/wiki/Quick-Start">Quick Start</a> guide and the <a href="https://github.com/cefsharp/CefSharp/wiki/Frequently-asked-questions">FAQ</a>.
+           CefSharp is the the easiest way to embed a full-featured standards-compliant web browser into your C# or VB.NET app. CefSharp has browser controls for WinForms and WPF apps, and a headless (offscreen) version for automation projects too. CefSharp is based on <a href="https://bitbucket.org/chromiumembedded/cef">Chromium Embedded Framework</a>, the open source version of <a href="https://www.google.com/chrome/">Google Chrome</a>. We have a simple 5 step process to get started. See the <a href="https://github.com/cefsharp/CefSharp/wiki/Quick-Start">Quick Start</a> guide and the <a href="https://github.com/cefsharp/CefSharp/wiki/Frequently-asked-questions">FAQ</a>.
         </div>
         <div class="featlist-code">
         </div>


### PR DESCRIPTION
credit goes to @dascentral who noticed this. Fixes typo on homepage of cefsharp.github.io. 